### PR TITLE
fix: resolve ZeroDivisionError in calculate_average() when input is empty

### DIFF
--- a/src/calculate_average.py
+++ b/src/calculate_average.py
@@ -1,0 +1,5 @@
+def calculate_average(values: list[float]) -> float:
+    """Return the arithmetic mean of values, or 0 if the list is empty."""
+    if not values:
+        return 0
+    return sum(values) / len(values)


### PR DESCRIPTION
## Root Cause Analysis
`calculate_average()` computes the mean by dividing the sum of elements by the length of the list (`sum(values) / len(values)`). When an empty list is passed, `len(values)` evaluates to 0, raising a `ZeroDivisionError`.

## Proposed Solution
Added a guard clause `if not values: return 0` before the division so the function short-circuits when given an empty list, preventing the `ZeroDivisionError`.

## Changes Made
- Added safety check for empty lists.
- Included clean type hints and documentation.
- No external dependencies added.

_Submitted automatically via Bounties Bot Core._