### PR TITLE
docs: add Tokyo weather snapshot (auto-generated)

### DIFF
--- a/tokyo-weather-note.md
+++ b/tokyo-weather-note.md
@@ -1,0 +1,28 @@
+# 🌤️ Tokyo Weather Snapshot
+
+> **Auto-generated snapshot** — captured on 2026-05-30 at 12:35 JST
+
+## Current Weather
+
+| Metric | Value |
+|---|---|
+| **Condition** | Sunny ☀️ |
+| **Temperature** | 29.2 °C (84.6 °F) |
+| **Feels Like** | 28.4 °C (83.1 °F) |
+| **Humidity** | 33% |
+| **Wind** | 22.0 kph from S |
+| **UV Index** | 9.9 (Very High) |
+| **Visibility** | 10 km |
+| **Precipitation** | 0.0 mm |
+
+## Sports Events
+
+One upcoming sports event was found near Tokyo:
+
+- **Football — International Match**: Japan vs Iceland at Japan National Stadium, scheduled for 2026-05-31 at 11:25 local time.
+
+No cricket or golf events were listed at the time of this snapshot.
+
+---
+
+_⚠️ This file was automatically generated as a weather-driven documentation demo. Data is a point-in-time snapshot and will become stale._


### PR DESCRIPTION
## Summary\n\nThis PR adds a new file **`tokyo-weather-note.md`** containing an automatically generated point-in-time weather snapshot for Tokyo, Japan.\n\n### What's included\n\n- **Current weather conditions** — temperature, humidity, wind, UV index, visibility, and precipitation as of 2026-05-30 12:35 JST.\n- **Nearby sports events** — one upcoming football match (Japan vs Iceland at Japan National Stadium on 2026-05-31).\n- A timestamped disclaimer noting that this is auto-generated data and will become stale.\n\n### Why\n\nThis is a small weather-driven documentation demo to illustrate how live data can be captured and committed to a repository. The sports-events section in particular may need review since event schedules change rapidly.\n\n> ⚠️ Opened as a **draft** — please review and promote to ready when appropriate.