### PR TITLE
chore: add CI badge to README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm test

--- a/README
+++ b/README
@@ -1,1 +1,2 @@
+![CI](https://github.com/octocat/Hello-World/actions/workflows/ci.yml/badge.svg)
 Hello World!


### PR DESCRIPTION
Add a GitHub Actions CI workflow and CI status badge to the README. Closes ISS-15.